### PR TITLE
Release v1.0.0

### DIFF
--- a/layouts/heading/layout.json
+++ b/layouts/heading/layout.json
@@ -7,6 +7,20 @@
       "name": "title",
       "type": "text",
       "description": "title text"
+    },
+    {
+      "name": "contentSize",
+      "type": "select",
+      "description": "content size",
+      "options": [
+        "fc-h1-text",
+        "fc-h2-text",
+        "fc-h3-text",
+        "fc-h4-text",
+        "fc-h5-text",
+        "fc-h6-text",
+        "fc-content-text"
+      ]
     }
   ],
   "values": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/fastcomposer",
-  "version": "1.0.0-pre2",
+  "version": "1.0.0",
   "author": "fastcampus",
   "main": "dist/fastcomposer.umd.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/fastcomposer",
-  "version": "1.0.0-pre1",
+  "version": "1.0.0-pre2",
   "author": "fastcampus",
   "main": "dist/fastcomposer.umd.js",
   "publishConfig": {

--- a/src/assets/scss/base/_reset.scss
+++ b/src/assets/scss/base/_reset.scss
@@ -2,6 +2,9 @@
 * base styles
 */
 
+* {
+  box-sizing: border-box;
+}
 html {
   font-size: 62.5%;
 }

--- a/src/assets/scss/utils/_variable.scss
+++ b/src/assets/scss/utils/_variable.scss
@@ -91,8 +91,8 @@ $white-d1: #f8f8f8;
 $white-d2: #f2f2f2;
 
 // color schemes (temporary)
-$primary: #2c2c2c; // $blue;
-$secondary: #1b1b1b; // $blue-d1;
+$primary: #292929; // $blue;
+$secondary: #181818; // $blue-d1;
 $accent: $blue-d1;
 $dimmed: $white-d1;
 $placehold: $grey-d2;

--- a/src/components/layout-info.vue
+++ b/src/components/layout-info.vue
@@ -39,6 +39,10 @@ export default {
 
     margin-right: 0.8rem;
   }
+  &.small &__icon {
+    width: $layer-icon-size * 0.64;
+    height: $layer-icon-size * 0.64;
+  }
 
   &__label {
     line-height: 2rem;
@@ -46,6 +50,14 @@ export default {
     > strong {
       @include readable-font-features;
       font-size: 1.6rem;
+    }
+  }
+  &.small &__label {
+    line-height: 1.6rem;
+    font-size: 1.2rem;
+
+    > strong {
+      font-size: 1.4rem;
     }
   }
 }

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -350,6 +350,7 @@
         const to = !(this.checkedCount === this.layers.length)
         this.layers.forEach(layer => this.$set(layer, 'isChecked', to))
       },
+      // FIXME this whole up/down logics totally does not work
       onUpBlock() {
         const checkedLayer = this.layers.filter(layer => layer.isChecked);
         const { uniqueId } = checkedLayer[0];
@@ -468,6 +469,7 @@
         $targetLayer && $targetLayer.scrollIntoView({ block: 'center' });
       },
       onUploadFile(fileInfo, callback) {
+        // FIXME ???
         this.$emit('uploadFile', fileInfo, callback);
       },
       setLayouts(layouts) {
@@ -544,6 +546,7 @@
       onShowLayouts() {
         this.$refs.layouts.toggle();
       },
+      // TODO what does focuses do?
       focusEditor() {
         this.isLeftVisible = true;
         this.$refs.editor.focus();
@@ -784,6 +787,7 @@
     max-width: $sidebar-size;
     color: $white;
 
+    /* TODO rewrite markup (dirty class names/selectors) */
     &__header {
       width: 100%;
       display: flex;
@@ -818,6 +822,8 @@
       }
     }
 
+    /* TODO rewrite markup (dirty class names/selectors) */
+    /* (yes, whole header buttons) */
     &__btn {
       position: absolute;
       top: 50%;

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -643,7 +643,7 @@
     position: absolute;
     top: 0;
     left: 0;
-    z-index: 10000;
+    z-index: 20000;
     &__content {
       position: absolute;
       top: 0;
@@ -777,7 +777,7 @@
   .fc-aside {
     display: flex;
     position: relative;
-    z-index: 10;
+    z-index: 10000;
     box-sizing: border-box;
     padding-bottom: 2rem;
     /* width: 0; */

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -843,6 +843,9 @@
         &:disabled {
           opacity: 0.3333;
         }
+        &:hover {
+          background: #8886;
+        }
 
         label {
           padding: 0 0.4rem;

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -779,7 +779,6 @@
     position: relative;
     z-index: 10000;
     box-sizing: border-box;
-    padding-bottom: 2rem;
     /* width: 0; */
     width: 100%;
     max-width: $sidebar-size;

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -77,10 +77,19 @@
               </button>
             </header>
             <header class="fc-aside__header">
-              <button class="btn" @click="onUpBlock" :disabled="!checkedCount">
+              <button class="btn narrow" @click="onSelectToggleAll" :disabled="!layers.length">
+                <span class="material-icons">{{
+                  checkedCount?
+                    checkedCount === layers.length?
+                      'check_box'
+                    : 'indeterminate_check_box'
+                 : 'check_box_outline_blank'
+                }}</span>
+              </button>
+              <button class="btn narrow" @click="onUpBlock" :disabled="!checkedCount || layers.length < 2">
                 <span class="material-icons">arrow_upward</span>
               </button>
-              <button class="btn" @click="onDownBlock" :disabled="!checkedCount">
+              <button class="btn narrow" @click="onDownBlock" :disabled="!checkedCount || layers.length < 2">
                 <span class="material-icons">arrow_downward</span>
               </button>
               <label class="fc-aside__header__label">
@@ -336,6 +345,10 @@
         }
 
         this.localStorageService.set(this.favoriteLayoutIds);
+      },
+      onSelectToggleAll() {
+        const to = !(this.checkedCount === this.layers.length)
+        this.layers.forEach(layer => this.$set(layer, 'isChecked', to))
       },
       onUpBlock() {
         const checkedLayer = this.layers.filter(layer => layer.isChecked);
@@ -851,8 +864,9 @@
           padding: 0 0.4rem;
           line-height: 2.4rem;
         }
-        &:hover {
-          background: #0002;
+        &.narrow {
+          padding-right: 0;
+          padding-left: 0;
         }
       }
 

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -797,7 +797,7 @@
         flex-grow: 10000;
         text-align: center;
       }
-      .material-icons {
+      small, .material-icons {
         vertical-align: top;
       }
     }
@@ -813,6 +813,10 @@
       padding: 1.2rem 0.9rem 11rem;
       height: percentage(1);
       background-color: $secondary;
+
+      .fc-aside--right & {
+        padding: 0;
+      }
     }
 
     &__btn {

--- a/src/views/editor/editor.vue
+++ b/src/views/editor/editor.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="fc-editor">
     <layout-info :layout="layer.layout" />
+    <!-- TODO - rewrite with <edit> component -->
     <form v-if="layer.layout" class="fc-editor__form" @submit.prevent="">
       <fieldset v-for="param in layer.layout.params" :key="param.name" class="fc-editor__form__fieldset">
         <label class="fc-editor__form__label" :for="toInputId(param)">
@@ -271,7 +272,7 @@ export default {
     position: relative;
     margin: 0 1.8rem 1.2rem;
   }
-
+  /* TODO will be refactored into separated components (all below this) */
   &__form {
 
     &__fieldset {

--- a/src/views/editor/editor.vue
+++ b/src/views/editor/editor.vue
@@ -232,7 +232,7 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import '../../assets/scss/utils/utilities';
 .fc-editor {
   position: relative;

--- a/src/views/editor/editor.vue
+++ b/src/views/editor/editor.vue
@@ -308,7 +308,7 @@ export default {
       background-color: #242424;
       color: #eee;
       outline: 0 none;
-      border-bottom: 0.2rem solid #444;
+      border-bottom: 0.2rem solid #555;
 
       transition: background-color 250ms ease, border-color 250ms ease;
 
@@ -356,7 +356,7 @@ export default {
       border: none;
       padding: 0.2rem 0.6rem;
 
-      border: 0.2rem solid #444;
+      border: 0.2rem solid #555;
 
       cursor: pointer;
       transition: background-color 250ms ease, border-color 250ms ease;

--- a/src/views/editor/editor.vue
+++ b/src/views/editor/editor.vue
@@ -52,11 +52,12 @@
         </template>
 
         <template v-else-if="param.type === 'text'">
-          <textarea
+          <input
+            type="text"
             :id="toInputId(param)"
             v-model="layer.values[param.name]"
-            class="fc-editor__form__textarea fc-editor__form__textarea--short"
-          ></textarea>
+            class="fc-editor__form__input"
+          />
         </template>
 
         <template v-else-if="param.type === 'list'">
@@ -118,11 +119,12 @@
                   </select>
                 </template>
                 <template v-else-if="childParams.type === 'text'">
-                  <textarea
+                  <input
+                    type="text"
                     :id="toInputId(param, childParams, index)"
                     v-model="item[childParams.name]"
-                    class="fc-editor__form__textarea fc-editor__form__textarea--short"
-                  ></textarea>
+                    class="fc-editor__form__input"
+                  />
                 </template>
 
                 <template v-else>

--- a/src/views/editor/editor.vue
+++ b/src/views/editor/editor.vue
@@ -51,6 +51,14 @@
           </select>
         </template>
 
+        <template v-else-if="param.type === 'text'">
+          <textarea
+            :id="toInputId(param)"
+            v-model="layer.values[param.name]"
+            class="fc-editor__form__textarea fc-editor__form__textarea--short"
+          ></textarea>
+        </template>
+
         <template v-else-if="param.type === 'list'">
           <div class="fc-editor__list">
             <div v-for="(item, index) in layer.values[param.name]" :key="index" class="fc-editor__list-item">
@@ -109,6 +117,14 @@
                     <option v-for="(option, index) in childParams.options" :key="index">{{ option }}</option>
                   </select>
                 </template>
+                <template v-else-if="childParams.type === 'text'">
+                  <textarea
+                    :id="toInputId(param, childParams, index)"
+                    v-model="item[childParams.name]"
+                    class="fc-editor__form__textarea fc-editor__form__textarea--short"
+                  ></textarea>
+                </template>
+
                 <template v-else>
                   <input
                     :id="toInputId(param, childParams, index)"
@@ -257,6 +273,8 @@ export default {
       font-size: 1.4rem;
       align-items: baseline;
 
+      user-select: none;
+
       > small {
         font-size: 1.2rem;
         margin-left: 0.4rem;
@@ -279,42 +297,106 @@ export default {
     &__textarea, &__input, &__select {
       @include readable-font-features;
       box-sizing: border-box;
-      display: block;
       border: none;
-      padding-left: 0.8rem;
-      width: 100%;
+      padding: 0 0 0 0.8rem;
 
       font-size: 1.4rem;
+      line-height: 2.2rem;
 
-      background-color: #080808;
-      color: white;
+      background-color: #242424;
+      color: #eee;
       outline: 0 none;
+      border-bottom: 0.2rem solid #444;
 
-      @include transition(background-color, 0.2s);
+      transition: background-color 250ms ease, border-color 250ms ease;
 
       &:focus {
-        background-color: darken(#1a237e, 15%);
+        background-color: #404040;
+        border-color: #eee;
       }
 
       &::selection {
         background: white;
-        color: black;
       }
+    }
+
+    &__textarea, &__input, &__select {
+      display: block;
+      width: 100%;
     }
 
     &__textarea {
       resize: vertical;
-      padding-top: 0.8rem;
+      padding-top: 0.4rem;
+      min-height: 3.4rem;
+      max-height: 32rem;
+
+      &--short {
+        height: 3.4rem;
+      }
     }
 
     &__input, &__select {
-      height: 2.5em;
-      line-height: 1.5em;
+      height: 3.4rem;
     }
 
     &__select {
-      padding-right: 0.4rem;
-      padding-left: 0.4rem;
+      padding: 0.8rem 0.4rem;
+    }
+
+    input[type="file"] {
+      color: #888;
+      cursor: pointer;
+    }
+    ::file-selector-button {
+      background-color: #8883;
+      color: inherit;
+      border: none;
+      padding: 0.2rem 0.6rem;
+
+      border: 0.2rem solid #444;
+
+      cursor: pointer;
+      transition: background-color 250ms ease, border-color 250ms ease;
+
+      &:hover {
+        background-color: #8884;
+      }
+      &:active {
+        background-color: #8885;
+      }
+      &:active, &:focus {
+        border-color: #eee;
+      }
+    }
+
+    ::-webkit-inner-spin-button {
+      margin-right: 0.4rem;
+    }
+
+    .fc-file-upload {
+      display: flex;
+      flex-wrap: wrap;
+      color: inherit;
+      margin-top: 0.4rem;
+
+      button {
+        margin-left: auto;
+        color: inherit;
+      }
+
+      .progress {
+        width: 100%;
+        height: 0.4rem;
+        margin: 0.4rem 0 0 0;
+        background: $primary;
+        border-radius: 0;
+
+        &-bar {
+          height: 100%;
+          background: #fff;
+        }
+      }
     }
 
     .required {
@@ -327,7 +409,7 @@ export default {
   &__list {
     &-item {
       border-left: 0.4rem solid $primary;
-      padding-left: 1.6rem;
+      padding-left: 1.2rem;
       margin-bottom: 1.2rem;
 
       &:nth-child(2n + 1) {
@@ -336,7 +418,7 @@ export default {
     }
     &-tools {
       display: flex;
-      margin-left: -0.8rem;
+      margin-left: -0.6rem;
       line-height: 2.6rem;
 
       button {

--- a/src/views/editor/editor.vue
+++ b/src/views/editor/editor.vue
@@ -52,12 +52,11 @@
         </template>
 
         <template v-else-if="param.type === 'text'">
-          <input
-            type="text"
+          <textarea
             :id="toInputId(param)"
             v-model="layer.values[param.name]"
-            class="fc-editor__form__input"
-          />
+            class="fc-editor__form__textarea fc-editor__form__textarea--short"
+          ></textarea>
         </template>
 
         <template v-else-if="param.type === 'list'">
@@ -119,12 +118,11 @@
                   </select>
                 </template>
                 <template v-else-if="childParams.type === 'text'">
-                  <input
-                    type="text"
+                  <textarea
                     :id="toInputId(param, childParams, index)"
                     v-model="item[childParams.name]"
-                    class="fc-editor__form__input"
-                  />
+                    class="fc-editor__form__textarea fc-editor__form__textarea--short"
+                  ></textarea>
                 </template>
 
                 <template v-else>

--- a/src/views/editor/editor.vue
+++ b/src/views/editor/editor.vue
@@ -56,6 +56,8 @@
             :id="toInputId(param)"
             v-model="layer.values[param.name]"
             class="fc-editor__form__textarea fc-editor__form__textarea--short"
+            @focus="resizeTextarea"
+            @input="resizeTextarea"
           ></textarea>
         </template>
 
@@ -122,6 +124,8 @@
                     :id="toInputId(param, childParams, index)"
                     v-model="item[childParams.name]"
                     class="fc-editor__form__textarea fc-editor__form__textarea--short"
+                    @focus="resizeTextarea"
+                    @input="resizeTextarea"
                   ></textarea>
                 </template>
 
@@ -242,6 +246,13 @@ export default {
         id += '-' + child.name
       }
       return id
+    },
+    resizeTextarea(event) {
+      const { target } = event
+      const { scrollHeight, clientHeight } = target
+      if(scrollHeight > clientHeight) {
+        target.style.height = (scrollHeight + 4) + 'px'
+      }
     }
   },
 };

--- a/src/views/editor/editor.vue
+++ b/src/views/editor/editor.vue
@@ -349,25 +349,31 @@ export default {
     input[type="file"] {
       color: #888;
       cursor: pointer;
-    }
-    ::file-selector-button {
-      background-color: #8883;
-      color: inherit;
-      border: none;
-      padding: 0.2rem 0.6rem;
+      outline: none;
 
-      border: 0.2rem solid #555;
+      &::file-selector-button {
+        background-color: #8883;
+        color: inherit;
+        border: none;
+        padding: 0.2rem 0.6rem;
 
-      cursor: pointer;
-      transition: background-color 250ms ease, border-color 250ms ease;
+        border: 0.2rem solid #555;
 
-      &:hover {
-        background-color: #8884;
+        cursor: pointer;
+        transition: background-color 250ms ease, border-color 250ms ease;
+
+        &:hover {
+          background-color: #8884;
+        }
+        &:active {
+          background-color: #8885;
+        }
+        &:active, &:focus {
+          border-color: #eee;
+        }
       }
-      &:active {
+      &:focus::file-selector-button {
         background-color: #8885;
-      }
-      &:active, &:focus {
         border-color: #eee;
       }
     }

--- a/src/views/editor/editor.vue
+++ b/src/views/editor/editor.vue
@@ -221,10 +221,9 @@ export default {
     toInputId(param, child, index) {
       let id = this.layer.id
       id += '--' + param.name
-      id += '-' + param.type
       if(child && index >= 0) {
-        id += '-n' + index
-        id += '-' + child.type
+        id += '-item' + index
+        id += '-' + child.name
       }
       return id
     }

--- a/src/views/editor/file-upload.vue
+++ b/src/views/editor/file-upload.vue
@@ -1,25 +1,25 @@
 <template>
   <div class="fc-file-upload">
-    <div class="progress">
-      <div class="progress-bar" :style="`width: ${ statePercent }%`"></div>
-    </div>
     <template v-if="state === 'READY'">
       <form enctype="multipart/form-data">
         <input type="file" :name="name" :accept="accept" @change="upload($event.target.files)" />
       </form>
     </template>
     <template v-if="state === 'UPLOADING'">
-      <div>업로드 중</div>
+      <div> 업로드 중 </div>
       <button type="button" @click="cancel">취소</button>
     </template>
     <template v-if="state === 'ERROR'">
-      <div>업로드 실패</div>
+      <div> 업로드 실패 </div>
       <button type="button" @click="cancel">취소</button>
     </template>
     <template v-if="state === 'UPLOADED'">
-      <div>업로드 완료</div>
+      <div> 업로드 완료 </div>
       <button type="button" @click="cancel">취소</button>
     </template>
+    <div class="progress" v-if="state !== 'READY'">
+      <div class="progress-bar" :style="`width: ${ statePercent }%`"></div>
+    </div>
   </div>
 </template>
 

--- a/src/views/header/header.vue
+++ b/src/views/header/header.vue
@@ -10,6 +10,7 @@
         <span v-show="saveTime">・ 최종 저장: {{ saveTime }}</span>
       </span>
     </div>
+    <!-- TODO: move/reimpl elsewhere -->
     <ul class="fc-header__favorite-layouts" v-if="favoriteLayouts.length">
       <li class="fc-header__favorite-layout" v-for="(layout, index) in favoriteLayouts" :key="index">
         <button class="fc-header__favorite-btn" @click="addLayer(layout)">
@@ -45,6 +46,7 @@
       }
     },
     props: {
+      // TODO cleanup unknowns & dirties (where's notif?) */
       favoriteLayoutIds: {
         type: Array,
         default() {
@@ -121,6 +123,7 @@
     transform: none; // admin과 충돌 이슈
     transition: none;  // admin과 충돌 이슈
 
+    /* TODO reconsider with other layout elms */
     &--no-favorites {
       height: $header-size * 0.5;
 

--- a/src/views/layers/layers.vue
+++ b/src/views/layers/layers.vue
@@ -3,7 +3,11 @@
     <Draggable class="fc-layer" v-for="(layer, index) in layers" :key="index">
       <div
         class="__item"
-        :class="{ '__item--active': index === currentLayerIndex, 'has-syntax-error-tags': layer.hasSyntaxErrorTags }"
+        :class="{
+          '__item--active': index === currentLayerIndex,
+          '__item--hidden': layer.hidden,
+          'has-syntax-error-tags': layer.hasSyntaxErrorTags
+        }"
         tabindex="0"
         @keydown.exact.enter.prevent="focusEditor"
         @keydown.exact.shift.up="updateCheckedState(currentLayerIndex - 1, $event)"
@@ -19,9 +23,10 @@
       >
         <div class="__item__group" v-if="layer.layout" @click="onSelect(index, $event, layer)">
           <label :for="`layer-${index}`" >
-            <input :id="`layer-${index}`" type="checkbox" v-model="layer.isChecked"/>
+            <input :id="`layer-${index}`" type="checkbox" v-model="layer.isChecked" style="display: none" />
+            <i class="material-icons">{{ layer.isChecked? 'check_box' : 'check_box_outline_blank' }}</i>
           </label>
-          <layout-info :layout="layer.layout"></layout-info>
+          <layout-info :layout="layer.layout" class="small"></layout-info>
         </div>
         <div class="__utils">
           <button class="__utils__btn" @click="onToggle(index)">
@@ -159,15 +164,20 @@
     },
   }
 </script>
-<style lang="scss" scoped>
+<style lang="scss">
   @import '../../assets/scss/utils/utilities';
-  .__item {
+  .fc-layer {
+    overflow: visible !important;
+    z-index: 10001 !important; /* overrided INLINE by vue plugin :facepalm: */
+  }
+  .fc-layer .__item {
     position: relative;
-    margin-bottom: 0.2rem;
-    padding: 0.4rem;
+    margin: 0.3rem 0 0 0.3rem;
+    padding: 0.4rem 0.4rem 0.4rem 0;
     cursor: pointer;
-    background: #1a237e;
+    background: $primary;
     font-size: 1.4rem;
+
     &:focus {
       outline-style: none;
     }
@@ -178,7 +188,14 @@
       }
     }
     &--active {
-      box-shadow: 0 0 0 0.3rem #ffffff inset;
+      background: lighten($primary, 15%);
+      box-shadow: 0 0 0 0.3rem #ffffff;
+    }
+    &--hidden .fc-layout-info {
+      opacity: 0.5;
+      strong {
+        text-decoration: line-through;
+      }
     }
     &__group {
       display: flex;
@@ -190,16 +207,22 @@
       label {
         display: inline-block;
         align-self: center;
+
+        > .material-icons {
+          vertical-align: top;
+          color: #fff8;
+        }
       }
     }
-  }
-  .__utils {
-    position: absolute;
-    top: 0.4rem;
-    right: 0.4rem;
 
-    &__btn {
-      color: transparentize($white, 0.5);
+    .__utils {
+      position: absolute;
+      top: 0.4rem;
+      right: 0.4rem;
+
+      &__btn {
+        color: #fff8;
+      }
     }
   }
 </style>

--- a/src/views/layers/layers.vue
+++ b/src/views/layers/layers.vue
@@ -174,7 +174,7 @@
   .fc-layer .__item {
     position: relative;
     margin: 0.3rem 0 0 0.3rem;
-    padding: 0.4rem 0.4rem 0.4rem 0;
+    padding: 0;
     cursor: pointer;
     background: $primary;
     font-size: 1.4rem;
@@ -205,19 +205,24 @@
     }
     &__group {
       display: flex;
+      align-items: stretch;
       flex-direction: row;
       width: percentage(1);
       color: $white;
       line-height: 2rem;
 
       label {
-        display: inline-block;
-        align-self: center;
+        display: inline-flex;
+        align-self: stretch;
+        align-items: center;
 
         > .material-icons {
           vertical-align: top;
           color: #fff6;
         }
+      }
+      .fc-layout-info {
+        padding: 0.4rem 0;
       }
     }
 

--- a/src/views/layers/layers.vue
+++ b/src/views/layers/layers.vue
@@ -5,6 +5,7 @@
         class="__item"
         :class="{
           '__item--active': index === currentLayerIndex,
+          '__item--checked': layer.isChecked,
           '__item--hidden': layer.hidden,
           'has-syntax-error-tags': layer.hasSyntaxErrorTags
         }"
@@ -197,6 +198,11 @@
         text-decoration: line-through;
       }
     }
+    &--checked {
+       .__item__group label .material-icons {
+        color: #fffe;
+      }
+    }
     &__group {
       display: flex;
       flex-direction: row;
@@ -210,7 +216,7 @@
 
         > .material-icons {
           vertical-align: top;
-          color: #fff8;
+          color: #fff6;
         }
       }
     }

--- a/src/views/layers/layers.vue
+++ b/src/views/layers/layers.vue
@@ -198,6 +198,7 @@
         text-decoration: line-through;
       }
     }
+    /* TODO cleanup */
     &--checked {
        .__item__group label .material-icons {
         color: #fffe;

--- a/src/views/layouts/layouts.vue
+++ b/src/views/layouts/layouts.vue
@@ -11,6 +11,7 @@
        @keydown.exact.page-down.prevent="focus(layoutIndex + 5)"
        @keydown.exact.esc.prevent="toggle"
   >
+    <!-- TODO: favorite layouts here? reimpl as sidebar?-->
     <ul class="fc-layout__list">
       <li v-for="(layout, index) in layouts" :key="index"
           class="fc-layout__list__item">

--- a/src/views/layouts/layouts.vue
+++ b/src/views/layouts/layouts.vue
@@ -118,7 +118,7 @@
     right: 4rem;
     width: 40rem;
     padding-bottom:2rem;
-    z-index: 9999;
+    z-index: 19999;
     color: white;
 
     &__list {

--- a/src/views/preview/preview.vue
+++ b/src/views/preview/preview.vue
@@ -116,6 +116,8 @@
       }
 
       &::after {
+        /* FIXME some layouts collide with this due to z-index */
+        /* remove those OR somehow just solve it (by creating new stack context? idk) */
         display: block;
         content: '';
         width: calc(100% - $gutter-width);


### PR DESCRIPTION
`v0.7.28` 모양 되는것보단 1.0 찍고 후딱후딱 올리는쪽이 나을거같아서 일단 찍습니다
뭔가 크게 다시 만들 때 v2.0로 가겠습니다


뭔가 한 번에 리뷰받긴 힘든 분량이긴 하지만 지금 작업단위를 찢으면 너무 세세해져서 이렇게 붙입니다

나중에 새로 짤 생각으로 대충 밀봉한 부분도 많으나 재구현중인 부분만 그랬으니 용서해주십시요 (...)

---

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5380174/183656571-f5191d93-a89e-4b7b-bc1a-0f62bb26e6cf.png">

## 바뀐 점 (incl. v1.0.0-pre1)

### 전역
- UI의 색상을 재검토
- Montserrat -> Pretendard
  - styleset을 적용하여 편집에 사용되는 문자들의 시인성을 향상
- `<layout-info>` 컴포넌트를 추가하여 파편화된 '레이아웃 정보'의 디자인을 쉽게 통일
- 사이드바 아래쪽의 바깥 여백 삭제

### 헤더
- 기능 버튼, 저장 버튼, 레이어 갯수 정보를 레이어 목록 위로 이동
  - 즐겨 찾는 레이아웃의 표시 영역을 크게 확보
- 버전을 표시
- 즐겨 찾는 레이아웃이 없을 때 높이를 반으로 함

### 레이어 목록
- 색상 재검토
- 버튼 위치 조정
- 선택된/점검 필요한 레이어가 없을 때 관련 텍스트 숨김
- 즐겨찾기 버튼을 레이어 목록으로 옮김
- 즐겨 찾는 레이아웃이 없을 때 상단 버튼이 헤더 위치에 있도록 올려 공간을 확보
- 항목 높이를 줄여 공간 절약
- 항목 버튼의 색상 조정

### 레이아웃 목록
- 위치 조정
- 즐겨찾기 버튼의 기능을 이 쪽으로 이동

### 편집
- 현재 편집 중인 레이아웃의 정보를 표시
- 시안성과 공간 활용을 위한 레이아웃 수정
  - '*필수'를 오른쪽 정렬
  - list의 경우 '항목 제거'를 항목 번호 옆으로
  - list의 경우 항목 구분이 가능하도록 여백과 세로선을 추가하고, 홀수와 짝수번째 항목의 세로선 색상을 서로 다르게 함
  - 파일 업로드 요소 디자인 반영
- `<label>`과 `<input>`의 연결을 바로잡음
- 일반 text 입력에도 `<textarea>`를 도입하여 편집 영역 확보 (*experimental)
- 등등...

### 프리뷰
- 해당 영역의 레이아웃 ID와 순서를 확인할 수 있도록 좌측에 gutter를 추가
- 선택된 레이아웃의 강조 표시가 내용물의 박스 크기에 영향을 주지 않도록 강조 표시 요소를 분리
- 임시로 z-index를 올려서 특정 사용처와의 충돌을 회피

--- 
> soundtrack: https://youtu.be/OBLN4O6rZs4