### PR TITLE
data.notificationMessage의 타입 및 기본값 변경

### DIFF
--- a/src/views/header/header.vue
+++ b/src/views/header/header.vue
@@ -54,11 +54,9 @@
         }
       },
       notificationMessage: {
-        type: Object,
+        type: String,
         default() {
-          return {
-            message: '',
-          }
+          return ''
         }
       },
       notificationType: {


### PR DESCRIPTION
`Invalid prop: type check failed for prop "notificationMessage". Expected Object, got String with value "".`

컴포저 실행시 fastcomposer/src/views/header/header.vue 컴포넌트에서 위와 같은 에러가 발생하고 있어 수정합니다.

prop을 부여하는 쪽에서 string을 주고 있고, 받는쪽의 이름도 notification이 아닌 notificationMessage라 받는쪽의 타입과 기본값을 변경했습니다.