### PR TITLE
sample.json 초깃값을 빈 배열로 수정

### DIFF
--- a/layouts/sample.json
+++ b/layouts/sample.json
@@ -1,6 +1,1 @@
-[{
-  "layout": "paragraph",
-  "values": {
-    "content": "본문"
-  }
-}]
+[]


### PR DESCRIPTION
로컬 환경에서 컴포저 레이아웃 테스트 중 오류가 발생하여 PR 생성했습니다. ([관련 스레드](https://day1c.slack.com/archives/C01BY5C1QVB/p1718177647831099?thread_ts=1718081570.264649&cid=C01BY5C1QVB))

<img width="1622" alt="스크린샷 2024-06-14 18 16 57" src="https://github.com/day1co/fastcomposer/assets/150231530/9399a3af-1fea-471f-91d5-755c6d698ea2">

프로젝트 초기 실행에서 위의 이미지와 같은 `Error: specified layout not found` 오류가 발생했습니다. 해당 오류는 sample.json 파일의 `paragraph` 에 해당하는 값을 찾지 못하여 발생하는 것으로 파악하였습니다.

sample.json 의 초깃값을 빈 배열로 수정하였을 때 오류가 해소되는 것으로 파악하여 PR 생성했습니다. 이와 같이 변경해도 사이드 이펙트가 발생하지 않을지 리뷰 부탁드립니다.