### PR TITLE
2.1.5: 스니펫 reference 복사되는 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/fastcomposer",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "author": "fastcampus",
   "main": "./dist/fastcomposer.js",
   "exports": {

--- a/src/legacy/views/index.vue
+++ b/src/legacy/views/index.vue
@@ -287,7 +287,8 @@
         this.focusEditor()
         this.currentTab = false
       },
-      onAddLayers(snippet) {
+      onAddLayers(_snippet) {
+        const snippet = structuredClone(_snippet)
         const remembered = this.state.act('layer.restore', this.currentLayer?.path, snippet)
 
         this.focusEditor()


### PR DESCRIPTION
FC-1525

### 버그 내용

1. 레이어 추가
2. 해당 레이어를 선택하고 스니펫하기
3. 스니펫 불러오기
4. 불러온 레이어를 편집
5. 두 레이어의 내용이 동시에 편집됨