### PR TITLE
[SEC-9906] 컴포저 페이지에서 세션 타임아웃 기능 개선

### DIFF
--- a/src/legacy/views/index.vue
+++ b/src/legacy/views/index.vue
@@ -265,9 +265,30 @@
             this.type = 'default';
           }
         },
+        lastInteractionHandler: null,
       };
     },
     methods: {
+      attachInteractionEvents() {
+        this.detachInteractionEvents();
+        this.lastInteractionHandler = () => {
+          localStorage.setItem('backoffice_last_interaction', Date.now().toString());
+        };
+        document.body.addEventListener('click', this.lastInteractionHandler);
+        document.body.addEventListener('keydown', this.lastInteractionHandler);
+        document.body.addEventListener('scroll', this.lastInteractionHandler);
+        document.body.addEventListener('touch', this.lastInteractionHandler);
+        document.body.addEventListener('mousemove', this.lastInteractionHandler);
+      },
+      detachInteractionEvents() {
+        if (this.lastInteractionHandler) {
+          document.body.removeEventListener('click', this.lastInteractionHandler);
+          document.body.removeEventListener('keydown', this.lastInteractionHandler);
+          document.body.removeEventListener('scroll', this.lastInteractionHandler);
+          document.body.removeEventListener('touch', this.lastInteractionHandler);
+          document.body.removeEventListener('mousemove', this.lastInteractionHandler);
+        }
+      },
       onAddFavoriteLayout(layoutId) {
         if (this.favoriteLayoutIds.includes(layoutId)) {
           this.favoriteLayoutIds.splice(this.favoriteLayoutIds.indexOf(layoutId), 1);
@@ -436,6 +457,7 @@
       }
     },
     mounted() {
+      this.attachInteractionEvents();
     },
     watch: {
       ['page.focusedIndex'](to) {
@@ -474,6 +496,7 @@
     },
     beforeDestroy() {
       EventBus.$off();
+      this.detachInteractionEvents();
     }
   };
 </script>


### PR DESCRIPTION
## 작업 내용
컴포저 페이지에서 세션 타임아웃 기능을 개선했습니다.

### 변경사항
1. 컴포저 컴포넌트에 사용자 인터랙션 감지 코드 추가
   - 이벤트: click, keydown, scroll, touch, mousemove
   - localStorage를 통해 마지막 상호작용 시간 공유
   - 컴포넌트 마운트/언마운트 시 이벤트 리스너 관리

### 개선 효과
- 컴포저가 새 창에서 열리더라도 사용자 활동이 감지되어 세션 타임아웃이 적절하게 연장됨
- classic-backoffice와 동일한 localStorage 키를 사용하여 세션 정보 공유
- 컴포저에서 작업 중일 때 세션이 만료되는 문제 해결

### 테스트 방법
1. classic-backoffice에서 컴포저 페이지를 새 창으로 열기
2. 컴포저에서 작업 수행 (레이아웃 편집, 텍스트 입력 등)
3. 메인 창의 세션이 유지되는지 확인
4. 컴포저 창에서 일정 시간 동안 작업하지 않으면 세션이 만료되는지 확인